### PR TITLE
Add StartDate to ApprenticeshipEarningsRecalculatedEvent

### DIFF
--- a/src/AcceptanceTests/SFA.DAS.Funding.ApprenticeshipEarnings.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/SFA.DAS.Funding.ApprenticeshipEarnings.AcceptanceTests.csproj
@@ -16,24 +16,24 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.33" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="4.0.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.7.2" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="SFA.DAS.NServiceBus" Version="17.0.13" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="SFA.DAS.Testing.AzureStorageEmulator" Version="3.0.169" />
     <PackageReference Include="SpecFlow.Plus.LivingDocPlugin" Version="3.9.57" />
     <PackageReference Include="SpecFlow.NUnit" Version="3.9.74" />
-    <PackageReference Include="nunit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="nunit" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="System.Runtime.InteropServices.WindowsRuntime" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Command.UnitTests/SFA.DAS.Funding.ApprenticeshipEarnings.Command.UnitTests.csproj
+++ b/src/Command.UnitTests/SFA.DAS.Funding.ApprenticeshipEarnings.Command.UnitTests.csproj
@@ -11,16 +11,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.18.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="Moq" Version="4.20.69" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0" />
-	  <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+	  <PackageReference Include="coverlet.msbuild" Version="6.0.2">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>

--- a/src/Command.UnitTests/SFA.DAS.Funding.ApprenticeshipEarnings.Command.UnitTests.csproj
+++ b/src/Command.UnitTests/SFA.DAS.Funding.ApprenticeshipEarnings.Command.UnitTests.csproj
@@ -28,6 +28,7 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
 	  <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.2.0" />
+	  <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Command/ApprenticeshipEarningsRecalculatedEventBuilder.cs
+++ b/src/Command/ApprenticeshipEarningsRecalculatedEventBuilder.cs
@@ -16,7 +16,8 @@ public class ApprenticeshipEarningsRecalculatedEventBuilder : IApprenticeshipEar
         {
             ApprenticeshipKey = apprenticeship.ApprenticeshipKey,
             DeliveryPeriods = apprenticeship.BuildDeliveryPeriods() ?? throw new ArgumentException("DeliveryPeriods"),
-            EarningsProfileId = apprenticeship.EarningsProfile.EarningsProfileId
+            EarningsProfileId = apprenticeship.EarningsProfile.EarningsProfileId,
+            StartDate = apprenticeship.ActualStartDate
         };
     }
 }

--- a/src/Command/ApprenticeshipEarningsRecalculatedEventBuilder.cs
+++ b/src/Command/ApprenticeshipEarningsRecalculatedEventBuilder.cs
@@ -17,7 +17,8 @@ public class ApprenticeshipEarningsRecalculatedEventBuilder : IApprenticeshipEar
             ApprenticeshipKey = apprenticeship.ApprenticeshipKey,
             DeliveryPeriods = apprenticeship.BuildDeliveryPeriods() ?? throw new ArgumentException("DeliveryPeriods"),
             EarningsProfileId = apprenticeship.EarningsProfile.EarningsProfileId,
-            StartDate = apprenticeship.ActualStartDate
+            StartDate = apprenticeship.ActualStartDate,
+            AgeAtStartOfApprenticeship = apprenticeship.AgeAtStartOfApprenticeship
         };
     }
 }

--- a/src/Command/ApprenticeshipEarningsRecalculatedEventBuilder.cs
+++ b/src/Command/ApprenticeshipEarningsRecalculatedEventBuilder.cs
@@ -17,8 +17,7 @@ public class ApprenticeshipEarningsRecalculatedEventBuilder : IApprenticeshipEar
             ApprenticeshipKey = apprenticeship.ApprenticeshipKey,
             DeliveryPeriods = apprenticeship.BuildDeliveryPeriods() ?? throw new ArgumentException("DeliveryPeriods"),
             EarningsProfileId = apprenticeship.EarningsProfile.EarningsProfileId,
-            StartDate = apprenticeship.ActualStartDate,
-            AgeAtStartOfApprenticeship = apprenticeship.AgeAtStartOfApprenticeship
+            StartDate = apprenticeship.ActualStartDate
         };
     }
 }

--- a/src/Command/ApproveStartDateChangeCommand/ApproveStartDateChangeCommandHandler.cs
+++ b/src/Command/ApproveStartDateChangeCommand/ApproveStartDateChangeCommandHandler.cs
@@ -18,7 +18,8 @@ public class ApproveStartDateChangeCommandHandler : IApproveStartDateChangeComma
     {
         var apprenticeshipDomainModel = command.ApprenticeshipEntity.GetDomainModel();
         var newStartDate = command.ApprenticeshipStartDateChangedEvent.ActualStartDate;
-        apprenticeshipDomainModel.RecalculateEarnings(newStartDate);
+        var newAgeAtStartOfApprenticeship = command.ApprenticeshipStartDateChangedEvent.AgeAtStartOfApprenticeship.GetValueOrDefault();
+        apprenticeshipDomainModel.RecalculateEarnings(newStartDate, newAgeAtStartOfApprenticeship);
         
         await _messageSession.Publish(_eventBuilder.Build(apprenticeshipDomainModel));
         

--- a/src/Command/SFA.DAS.Funding.ApprenticeshipEarnings.Command.csproj
+++ b/src/Command/SFA.DAS.Funding.ApprenticeshipEarnings.Command.csproj
@@ -7,11 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.2.0" />
     <PackageReference Include="NServiceBus" Version="7.8.2" />
-    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
-	<PackageReference Include="coverlet.collector" Version="3.1.0" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.6" />
+	<PackageReference Include="coverlet.collector" Version="6.0.2">
+	  <PrivateAssets>all</PrivateAssets>
+	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	</PackageReference>
 	<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.2.0" />
   </ItemGroup>
 

--- a/src/DataAccess/SFA.DAS.Funding.ApprenticeshipEarnings.DataAccess.csproj
+++ b/src/DataAccess/SFA.DAS.Funding.ApprenticeshipEarnings.DataAccess.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.26" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.26" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.2.0" />
-    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.6" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.2.0" />
   </ItemGroup>
 

--- a/src/Domain.UnitTests/ApprenticeshipFunding/WhenRecalculatingEarningsForStartDateChange.cs
+++ b/src/Domain.UnitTests/ApprenticeshipFunding/WhenRecalculatingEarningsForStartDateChange.cs
@@ -15,6 +15,7 @@ public class WhenRecalculatingEarningsForStartDateChange
     private Apprenticeship.Apprenticeship? _apprenticeshipBeforeStartDateChange; //represents the apprenticeship before the start date change
     private Apprenticeship.Apprenticeship? _sut; // represents the apprenticeship after the start date change
     private DateTime _updatedStartDate;
+    private int _updatedAgeAtApprenticeshipStart;
 
     public WhenRecalculatingEarningsForStartDateChange()
     {
@@ -25,22 +26,24 @@ public class WhenRecalculatingEarningsForStartDateChange
     public void SetUp()
     {
         _updatedStartDate = new DateTime(2021, 3, 15);
+        _updatedAgeAtApprenticeshipStart = _fixture.Create<int>();
         _apprenticeshipBeforeStartDateChange = CreateApprenticeship(_fixture.Create<decimal>(), new DateTime(2021, 1, 15), new DateTime(2021, 12, 31));
         _apprenticeshipBeforeStartDateChange.CalculateEarnings();
         _sut = CreateUpdatedApprenticeship(_apprenticeshipBeforeStartDateChange, _updatedStartDate);
     }
 
     [Test]
-    public void ThenTheActualStartDateIsUpdated()
+    public void ThenTheActualStartDateAndAgeAreUpdated()
     {
-        _sut!.RecalculateEarnings(_updatedStartDate);
+        _sut!.RecalculateEarnings(_updatedStartDate, _updatedAgeAtApprenticeshipStart);
         _sut.ActualStartDate.Should().Be(_updatedStartDate);
+        _sut.AgeAtStartOfApprenticeship.Should().Be(_updatedAgeAtApprenticeshipStart);
     }
 
     [Test]
     public void ThenTheEarningsProfileIsCalculated()
     {
-        _sut!.RecalculateEarnings(_updatedStartDate);
+        _sut!.RecalculateEarnings(_updatedStartDate, _updatedAgeAtApprenticeshipStart);
         _sut.EarningsProfile.OnProgramTotal.Should().Be(_apprenticeshipBeforeStartDateChange.EarningsProfile.OnProgramTotal);
         _sut.EarningsProfile.CompletionPayment.Should().Be(_apprenticeshipBeforeStartDateChange.EarningsProfile.CompletionPayment);
         _sut.EarningsProfile.EarningsProfileId.Should().NotBe(_apprenticeshipBeforeStartDateChange.EarningsProfile.EarningsProfileId);
@@ -53,7 +56,7 @@ public class WhenRecalculatingEarningsForStartDateChange
     [Test]
     public void ThenEarningsRecalculatedEventIsCreated()
     {
-        _sut!.RecalculateEarnings(_updatedStartDate);
+        _sut!.RecalculateEarnings(_updatedStartDate, _updatedAgeAtApprenticeshipStart);
 
         var events = _sut.FlushEvents();
         events.Should().ContainSingle(x => x.GetType() == typeof(EarningsRecalculatedEvent));
@@ -62,7 +65,7 @@ public class WhenRecalculatingEarningsForStartDateChange
     [Test]
     public void ThenTheEarningsProfileIdIsGenerated()
     {
-        _sut!.RecalculateEarnings(_updatedStartDate);
+        _sut!.RecalculateEarnings(_updatedStartDate, _updatedAgeAtApprenticeshipStart);
         _sut.EarningsProfile.EarningsProfileId.Should().NotBeEmpty();
     }
 

--- a/src/Domain.UnitTests/Factories/ApprenticeshipFactory/WhenCreatingANewApprenticeship.cs
+++ b/src/Domain.UnitTests/Factories/ApprenticeshipFactory/WhenCreatingANewApprenticeship.cs
@@ -24,19 +24,19 @@ namespace SFA.DAS.Funding.ApprenticeshipEarnings.Domain.UnitTests.Factories.Appr
 
             var apprenticeship = _factory.CreateNew(apprenticeshipEntityModel);
 
-            Assert.AreEqual(apprenticeshipEntityModel.ActualStartDate, apprenticeship.ActualStartDate);
-            Assert.AreEqual(apprenticeshipEntityModel.AgreedPrice, apprenticeship.AgreedPrice);
-            Assert.AreEqual(apprenticeshipEntityModel.EmployerAccountId, apprenticeship.EmployerAccountId);
-            Assert.AreEqual(apprenticeshipEntityModel.FundingEmployerAccountId, apprenticeship.FundingEmployerAccountId); 
-            Assert.AreEqual(apprenticeshipEntityModel.LegalEntityName, apprenticeship.LegalEntityName);
-            Assert.AreEqual(apprenticeshipEntityModel.PlannedEndDate, apprenticeship.PlannedEndDate);
-            Assert.AreEqual(apprenticeshipEntityModel.TrainingCode, apprenticeship.TrainingCode);
-            Assert.AreEqual(apprenticeshipEntityModel.UKPRN, apprenticeship.UKPRN);
-            Assert.AreEqual(apprenticeshipEntityModel.ApprenticeshipKey, apprenticeship.ApprenticeshipKey);
-            Assert.AreEqual(apprenticeshipEntityModel.ApprovalsApprenticeshipId, apprenticeship.ApprovalsApprenticeshipId);
-            Assert.AreEqual(apprenticeshipEntityModel.Uln, apprenticeship.Uln);
-            Assert.AreEqual(apprenticeshipEntityModel.FundingBandMaximum, apprenticeship.FundingBandMaximum);
-            Assert.AreEqual(apprenticeshipEntityModel.AgeAtStartOfApprenticeship, apprenticeship.AgeAtStartOfApprenticeship);
+            Assert.That(apprenticeshipEntityModel.ActualStartDate, Is.EqualTo(apprenticeship.ActualStartDate));
+            Assert.That(apprenticeshipEntityModel.AgreedPrice, Is.EqualTo(apprenticeship.AgreedPrice));
+            Assert.That(apprenticeshipEntityModel.EmployerAccountId, Is.EqualTo(apprenticeship.EmployerAccountId));
+            Assert.That(apprenticeshipEntityModel.FundingEmployerAccountId, Is.EqualTo(apprenticeship.FundingEmployerAccountId)); 
+            Assert.That(apprenticeshipEntityModel.LegalEntityName, Is.EqualTo(apprenticeship.LegalEntityName));
+            Assert.That(apprenticeshipEntityModel.PlannedEndDate, Is.EqualTo(apprenticeship.PlannedEndDate));
+            Assert.That(apprenticeshipEntityModel.TrainingCode, Is.EqualTo(apprenticeship.TrainingCode));
+            Assert.That(apprenticeshipEntityModel.UKPRN, Is.EqualTo(apprenticeship.UKPRN));
+            Assert.That(apprenticeshipEntityModel.ApprenticeshipKey, Is.EqualTo(apprenticeship.ApprenticeshipKey));
+            Assert.That(apprenticeshipEntityModel.ApprovalsApprenticeshipId, Is.EqualTo(apprenticeship.ApprovalsApprenticeshipId));
+            Assert.That(apprenticeshipEntityModel.Uln, Is.EqualTo(apprenticeship.Uln));
+            Assert.That(apprenticeshipEntityModel.FundingBandMaximum, Is.EqualTo(apprenticeship.FundingBandMaximum));
+            Assert.That(apprenticeshipEntityModel.AgeAtStartOfApprenticeship, Is.EqualTo(apprenticeship.AgeAtStartOfApprenticeship));
         }
     }
 }

--- a/src/Domain.UnitTests/SFA.DAS.Funding.ApprenticeshipEarnings.Domain.UnitTests.csproj
+++ b/src/Domain.UnitTests/SFA.DAS.Funding.ApprenticeshipEarnings.Domain.UnitTests.csproj
@@ -26,6 +26,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.2.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/Domain.UnitTests/SFA.DAS.Funding.ApprenticeshipEarnings.Domain.UnitTests.csproj
+++ b/src/Domain.UnitTests/SFA.DAS.Funding.ApprenticeshipEarnings.Domain.UnitTests.csproj
@@ -9,19 +9,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.18.0" />
-    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="Moq" Version="4.18.1" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Domain/Apprenticeship/Apprenticeship.cs
+++ b/src/Domain/Apprenticeship/Apprenticeship.cs
@@ -48,7 +48,7 @@ public class Apprenticeship : AggregateRoot
     public long? FundingEmployerAccountId { get; }
     public FundingType FundingType { get; }
     public decimal FundingBandMaximum { get; }
-    public int AgeAtStartOfApprenticeship { get; }
+    public int AgeAtStartOfApprenticeship { get; private set; }
     public EarningsProfile? EarningsProfile { get; private set; }
 
     public string FundingLineType =>
@@ -74,9 +74,10 @@ public class Apprenticeship : AggregateRoot
         AddEvent(new EarningsRecalculatedEvent(this));
     }
 
-    public void RecalculateEarnings(DateTime newStartDate)
+    public void RecalculateEarnings(DateTime newStartDate, int ageAtStartOfApprenticeship)
     {
         ActualStartDate = newStartDate;
+        AgeAtStartOfApprenticeship = ageAtStartOfApprenticeship;
         var apprenticeshipFunding = new ApprenticeshipFunding.ApprenticeshipFunding(AgreedPrice, newStartDate, PlannedEndDate, FundingBandMaximum);
         var newEarnings = apprenticeshipFunding.RecalculateEarnings(newStartDate);
         EarningsProfile = new EarningsProfile(apprenticeshipFunding.OnProgramTotal, newEarnings.Select(x => new Instalment(x.AcademicYear, x.DeliveryPeriod, x.Amount)).ToList(), apprenticeshipFunding.CompletionPayment, Guid.NewGuid());

--- a/src/Domain/SFA.DAS.Funding.ApprenticeshipEarnings.Domain.csproj
+++ b/src/Domain/SFA.DAS.Funding.ApprenticeshipEarnings.Domain.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SFA.DAS.Apprenticeships.Types" Version="6.8.1-prerelease-84" />
-    <PackageReference Include="Scrutor" Version="4.2.0" />
+    <PackageReference Include="SFA.DAS.Apprenticeships.Types" Version="6.8.3-prerelease-38" />
+    <PackageReference Include="Scrutor" Version="4.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableEntities.Models/SFA.DAS.Funding.ApprenticeshipEarnings.DurableEntities.Models.csproj
+++ b/src/DurableEntities.Models/SFA.DAS.Funding.ApprenticeshipEarnings.DurableEntities.Models.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="SFA.DAS.Apprenticeships.Types" Version="6.8.1-prerelease-84" />
+    <PackageReference Include="SFA.DAS.Apprenticeships.Types" Version="6.8.3-prerelease-38" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DurableEntities.UnitTests/SFA.DAS.Funding.ApprenticeshipEarnings.DurableEntities.UnitTests.csproj
+++ b/src/DurableEntities.UnitTests/SFA.DAS.Funding.ApprenticeshipEarnings.DurableEntities.UnitTests.csproj
@@ -9,18 +9,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.18.0" />
-    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="Moq" Version="4.18.1" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.2.0" />
   </ItemGroup>
 

--- a/src/DurableEntities.UnitTests/WhenApprenticeshipEntityHandlesStartDateChangeApproved.cs
+++ b/src/DurableEntities.UnitTests/WhenApprenticeshipEntityHandlesStartDateChangeApproved.cs
@@ -69,6 +69,7 @@ public class WhenApprenticeshipEntityHandlesStartDateChangeApproved
             ApprenticeshipKey = _apprenticeshipCreatedEvent.ApprenticeshipKey,
             ApprenticeshipId = 123,
             ActualStartDate = _apprenticeship.ActualStartDate.AddMonths(3),
+            AgeAtStartOfApprenticeship = _fixture.Create<int>(),
             EmployerAccountId = _apprenticeshipCreatedEvent.EmployerAccountId,
             ProviderId = 123,
             ApprovedDate = new DateTime(2023, 2, 15),
@@ -76,7 +77,7 @@ public class WhenApprenticeshipEntityHandlesStartDateChangeApproved
             EmployerApprovedBy = "",
             Initiator = ""
         };
-        _apprenticeship.RecalculateEarnings(_startDateChangedEvent.ActualStartDate);
+        _apprenticeship.RecalculateEarnings(_startDateChangedEvent.ActualStartDate, _startDateChangedEvent.AgeAtStartOfApprenticeship.GetValueOrDefault());
 
         _createApprenticeshipCommandHandler = new Mock<ICreateApprenticeshipCommandHandler>();
         _approvePriceChangeCommandHandler = new Mock<IApprovePriceChangeCommandHandler>();
@@ -99,6 +100,7 @@ public class WhenApprenticeshipEntityHandlesStartDateChangeApproved
         _sut.Model.EarningsProfile.CompletionPayment.Should().Be(_apprenticeship.EarningsProfile.CompletionPayment);
         _sut.Model.EarningsProfile.EarningsProfileId.Should().Be(_apprenticeship.EarningsProfile.EarningsProfileId);
         _sut.Model.EarningsProfile.Instalments.Should().BeEquivalentTo(_apprenticeship.EarningsProfile.Instalments);
+        _sut.Model.AgeAtStartOfApprenticeship.Should().Be(_startDateChangedEvent.AgeAtStartOfApprenticeship);
     }
 
     [Test]

--- a/src/DurableEntities/ApprenticeshipEntity.cs
+++ b/src/DurableEntities/ApprenticeshipEntity.cs
@@ -57,6 +57,7 @@ public class ApprenticeshipEntity
         var newEarnings = MapEarningsProfileToModel(apprenticeship.EarningsProfile);
             
         Model.ActualStartDate = apprenticeship.ActualStartDate;
+        Model.AgeAtStartOfApprenticeship = apprenticeship.AgeAtStartOfApprenticeship;
 
         SupersedeEarningsProfile(newEarnings);
 

--- a/src/DurableEntities/SFA.DAS.Funding.ApprenticeshipEarnings.DurableEntities.csproj
+++ b/src/DurableEntities/SFA.DAS.Funding.ApprenticeshipEarnings.DurableEntities.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NServiceBus.Extensions.DependencyInjection" Version="1.0.1" />
-    <PackageReference Include="SFA.DAS.Apprenticeships.Types" Version="6.8.1-prerelease-84" />
+    <PackageReference Include="SFA.DAS.Apprenticeships.Types" Version="6.8.3-prerelease-38" />
     <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="3.0.84" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.2.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/src/Infrastructure/SFA.DAS.Funding.ApprenticeshipEarnings.Infrastructure.csproj
+++ b/src/Infrastructure/SFA.DAS.Funding.ApprenticeshipEarnings.Infrastructure.csproj
@@ -9,12 +9,12 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.11.3" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NServiceBus.Extensions.DependencyInjection" Version="1.0.1" />
     <PackageReference Include="SFA.DAS.NServiceBus.AzureFunction" Version="17.0.13" />
-    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.6" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.2.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.4" />

--- a/src/Queries/SFA.DAS.Funding.ApprenticeshipEarnings.Queries.csproj
+++ b/src/Queries/SFA.DAS.Funding.ApprenticeshipEarnings.Queries.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Scrutor" Version="4.2.0" />
+    <PackageReference Include="Scrutor" Version="4.2.2" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.2.0" />
   </ItemGroup>
 

--- a/src/SFA.DAS.ApprenticeshipEarnings.InnerApi.UnitTests/SFA.DAS.Funding.ApprenticeshipEarnings.InnerApi.UnitTests.csproj
+++ b/src/SFA.DAS.ApprenticeshipEarnings.InnerApi.UnitTests/SFA.DAS.Funding.ApprenticeshipEarnings.InnerApi.UnitTests.csproj
@@ -9,17 +9,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.18.0" />
-    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="Moq" Version="4.18.1" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.Funding.ApprenticeshipEarnings.DataAccess.UnitTests/SFA.DAS.Funding.ApprenticeshipEarnings.DataAccess.UnitTests.csproj
+++ b/src/SFA.DAS.Funding.ApprenticeshipEarnings.DataAccess.UnitTests/SFA.DAS.Funding.ApprenticeshipEarnings.DataAccess.UnitTests.csproj
@@ -26,6 +26,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.2.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/SFA.DAS.Funding.ApprenticeshipEarnings.DataAccess.UnitTests/SFA.DAS.Funding.ApprenticeshipEarnings.DataAccess.UnitTests.csproj
+++ b/src/SFA.DAS.Funding.ApprenticeshipEarnings.DataAccess.UnitTests/SFA.DAS.Funding.ApprenticeshipEarnings.DataAccess.UnitTests.csproj
@@ -9,19 +9,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.18.0" />
-    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.0" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.2.0" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>

--- a/src/SFA.DAS.Funding.ApprenticeshipEarnings.DataTransferObjects/SFA.DAS.Funding.ApprenticeshipEarnings.DataTransferObjects.csproj
+++ b/src/SFA.DAS.Funding.ApprenticeshipEarnings.DataTransferObjects/SFA.DAS.Funding.ApprenticeshipEarnings.DataTransferObjects.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SFA.DAS.Apprenticeships.Types" Version="6.8.1-prerelease-84" />
+    <PackageReference Include="SFA.DAS.Apprenticeships.Types" Version="6.8.3-prerelease-38" />
   </ItemGroup>
 
 </Project>

--- a/src/SFA.DAS.Funding.ApprenticeshipEarnings.Queries.UnitTests/SFA.DAS.Funding.ApprenticeshipEarnings.Queries.UnitTests.csproj
+++ b/src/SFA.DAS.Funding.ApprenticeshipEarnings.Queries.UnitTests/SFA.DAS.Funding.ApprenticeshipEarnings.Queries.UnitTests.csproj
@@ -23,6 +23,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.Funding.ApprenticeshipEarnings.Queries.UnitTests/SFA.DAS.Funding.ApprenticeshipEarnings.Queries.UnitTests.csproj
+++ b/src/SFA.DAS.Funding.ApprenticeshipEarnings.Queries.UnitTests/SFA.DAS.Funding.ApprenticeshipEarnings.Queries.UnitTests.csproj
@@ -9,17 +9,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.18.0" />
-    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="Moq" Version="4.18.1" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/TestHelpers/SFA.DAS.Funding.ApprenticeshipEarnings.TestHelpers.csproj
+++ b/src/TestHelpers/SFA.DAS.Funding.ApprenticeshipEarnings.TestHelpers.csproj
@@ -13,20 +13,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.18.0" />
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="Azure.Identity" Version="1.11.3" />
-    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.33" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.7.2" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
-    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="162.0.52" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
+    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="162.2.111" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="Polly" Version="7.2.3" />
-    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="Polly" Version="8.4.0" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.6" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.2.0" />
   </ItemGroup>
 

--- a/src/TestHelpers/SFA.DAS.Funding.ApprenticeshipEarnings.TestHelpers.csproj
+++ b/src/TestHelpers/SFA.DAS.Funding.ApprenticeshipEarnings.TestHelpers.csproj
@@ -28,6 +28,8 @@
     <PackageReference Include="Polly" Version="8.4.0" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.6" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.2.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Types/ApprenticeshipEarningsRecalculatedEvent.cs
+++ b/src/Types/ApprenticeshipEarningsRecalculatedEvent.cs
@@ -7,7 +7,6 @@
         public List<DeliveryPeriod> DeliveryPeriods { get; set; }
         public Guid EarningsProfileId { get; set; }
         public DateTime StartDate { get; set; }
-        public int AgeAtStartOfApprenticeship { get; set; }
     }
 #pragma warning restore CS8618
 }

--- a/src/Types/ApprenticeshipEarningsRecalculatedEvent.cs
+++ b/src/Types/ApprenticeshipEarningsRecalculatedEvent.cs
@@ -6,6 +6,7 @@
         public Guid ApprenticeshipKey { get; set; }
         public List<DeliveryPeriod> DeliveryPeriods { get; set; }
         public Guid EarningsProfileId { get; set; }
+        public DateTime StartDate { get; set; }
     }
 #pragma warning restore CS8618
 }

--- a/src/Types/ApprenticeshipEarningsRecalculatedEvent.cs
+++ b/src/Types/ApprenticeshipEarningsRecalculatedEvent.cs
@@ -7,6 +7,7 @@
         public List<DeliveryPeriod> DeliveryPeriods { get; set; }
         public Guid EarningsProfileId { get; set; }
         public DateTime StartDate { get; set; }
+        public int AgeAtStartOfApprenticeship { get; set; }
     }
 #pragma warning restore CS8618
 }


### PR DESCRIPTION
It's been acknowledged that this pattern of adding apprenticeship values that need updating in the payments domain to this event will bloat the event so this is a temporary solution to resolve the bug until the introduction of "ApprenticeshipEpisodes".